### PR TITLE
Change default RabbitMQ Passphrase

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ override['rabbitmq']['ssl_verify'] = 'verify_none'
 override['rabbitmq']['ssl_fail_if_no_peer_cert'] = false
 
 default['rabbit']['user'] = 'rabbit'
-default['rabbit']['password'] = 'hare'
+default['rabbit']['password'] = 'Ra1HMmfkIVATgzqL8889BsbBU3csehxR'
 
 default['rabbit']['domain'] = 'rabbitmq.opsworks.company.com'
 default['rabbit']['route_53_zone_id'] = nil


### PR DESCRIPTION
Due to the Base INI leak, we need to update the RabbitMQ credentials. If the RabbitMQ OpsWorks stack is ever created again, this will prevent using the old username/password.